### PR TITLE
Change to use getpass.getuser() to check for user wayland sessions

### DIFF
--- a/lib/emoji_shared.py
+++ b/lib/emoji_shared.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import getpass
 import json
 from collections import OrderedDict, deque
 from subprocess import run, PIPE
@@ -78,7 +79,7 @@ def check_wayland():
 	sessions = run(
 		['loginctl', 'list-sessions'], stdout=PIPE, universal_newlines=True)
 	for line in sessions.stdout.split('\n'):
-		if os.getlogin() in line:
+		if getpass.getuser() in line:
 			session = line.split()[0]
 	type_ = run(
 		['loginctl', 'show-session', session, '-p', 'Type'],


### PR DESCRIPTION
Using `os.getlogin()` on some distributions gives a `FileNotFound` error, this uses the getpass module instead which has friendlier methods to find the name of the current user.

Tested this as working both on a platform that worked as normal with `os.getlogin()` as well as a platform that didn't (Arch Linux with i3wm)