### PR TITLE
fix use of variable before it was assigned in setup.py

### DIFF
--- a/lib/emoji_shared.py
+++ b/lib/emoji_shared.py
@@ -80,15 +80,19 @@ def check_wayland():
 		['loginctl', 'list-sessions'], stdout=PIPE, universal_newlines=True)
 	current_user = getpass.getuser()
 	current_user = current_user if current_user != 'root' else os.getlogin()
+	session = None
 	for line in sessions.stdout.split('\n'):
 		if current_user in line:
 			session = line.split()[0]
-	type_ = run(
-		['loginctl', 'show-session', session, '-p', 'Type'],
-		stdout=PIPE, universal_newlines=True)
-	if type_.stdout == 'Type=x11\n':
+	if session == None:
 		return False
-	return True
+	else:
+		type_ = run(
+			['loginctl', 'show-session', session, '-p', 'Type'],
+		stdout=PIPE, universal_newlines=True)
+		if type_.stdout == 'Type=x11\n':
+			return False
+		return True
 
 def get_keycode():
 


### PR DESCRIPTION
this fixes the following error emitted by `setup.py` on my system (debian sid):

```
Traceback (most recent call last):
  File "./setup.py", line 5, in <module>
    from lib.emoji_shared import version
  File "/mnt/data/dev/packages/emoji-keyboard/lib/emoji_shared.py", line 102, in <module>
    wayland = check_wayland()
  File "/mnt/data/dev/packages/emoji-keyboard/lib/emoji_shared.py", line 87, in check_wayland
    ['loginctl', 'show-session', session, '-p', 'Type'],
UnboundLocalError: local variable 'session' referenced before assignment
```