### PR TITLE
ensure session variable exists

### DIFF
--- a/lib/emoji_shared.py
+++ b/lib/emoji_shared.py
@@ -76,6 +76,7 @@ search_visible = False
 
 def check_wayland():
 
+	session = ''
 	sessions = run(
 		['loginctl', 'list-sessions'], stdout=PIPE, universal_newlines=True)
 	current_user = getpass.getuser()


### PR DESCRIPTION
The session variable is not guaranteed to exist, and in fact, does not exist when run under Arch (KDE).  https://aur.archlinux.org/packages/emoji-keyboard
patches the code in order to build, so probably better to add the fix in here.