### PR TITLE
Fixed issues with formatting, grammar, & commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,11 @@
 
 Virtual keyboard-like emoji picker for Linux.
 
-Emoji artwork and metadata provided by [Emoji Two](https://emojitwo.github.io/)
-by [Ranks.com](http://www.ranks.com/) and is licensed under
-[CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
-
-Additional artwork provided by
-[Twitter Emoji](https://github.com/twitter/twemoji)
-([CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode)) and
-[Noto Emoji](https://github.com/googlei18n/noto-emoji)
-([Apache 2.0](https://github.com/googlei18n/noto-emoji/blob/master/LICENSE)).
+Artwork and metadata are provided by the following:
+- [Ranks.com](http://www.ranks.com/)'s [Emoji Two](https://emojitwo.github.io/), licensed under
+[CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode)
+- [Twitter](https://twitter.com/)'s [Twemoji](https://github.com/twitter/twemoji), licensed under [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode)
+- [Google i18n](https://developers.google.com/international)'s [Noto Emoji](https://github.com/googlei18n/noto-emoji), licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 ## Installation
 
@@ -19,73 +15,65 @@ Additional artwork provided by
 **Dependency change: python3-xlib has been dropped in favor of python3-evdev**
 
 You'll need Python 3.5+ and GObject bindings, as well as python3-evdev package.
-If you're on a Debian based distro you can install them with
+If you're on a Debian based distro you can install them with this command:
 
-`sudo apt install python3 python3-gi gir1.2-gtk-3.0 gir1.2-glib-2.0
-python3-evdev`
+    sudo apt install python3 python3-gi gir1.2-gtk-3.0 gir1.2-glib-2.0 python3-evdev
 
-Optionally, if you want indicator in the panel:
+Optionally, if you want an indicator in the panel, execute the following:
 
-`sudo apt install gir1.2-appindicator3-0.1`
+    sudo apt install gir1.2-appindicator3-0.1
 
-If you're still on X, **DO** install python3-xlib. This will perform better and won't require modifications to the system.
-Prefer pip version if possible, because the one in debian archives is ancient.
+#### If your DE uses X
 
-`pip3 install python-xlib`
+Install `python3-xlib`, as it will perform better and won't require any further modifications. Using `pip` is preferred because the version installed by `apt` is outdated.
 
-**IF YOU'RE ON WAYLAND**
-You'll need to:
-- Create `uinput` group `sudo addgroup uinput`
-- Add yourself to this group `sudo adduser $(whoami) uinput`
-- Create udev rule. In the terminal type this:
-	- `sudo nano /etc/udev/rules.d/uinput.rules`
-	- `KERNEL=="uinput", GROUP="uinput", MODE="0660"`
-	- To save press `Ctrl+o` `Enter` `Ctrl+x`
+##### Installing via `pip`
 
-This will allow your user to create virtual devices for pasting emoji, without these steps Type mode WILL NOT WORK.
+    pip3 install python-xlib
+
+##### Installing via `apt`
+
+    sudo apt install python-xlib
+
+#### If your DE uses WAYLAND
+
+Open the terminal and do the following:
+- Create `uinput` group:
+
+      sudo addgroup uinput
+- Add yourself to the group:
+
+      sudo adduser $USERNAME uinput
+- Open `/etc/udev/rules.d/uinput.rules` as root in preferred text editor
+- Add the following text to new line, then save the file:
+
+      KERNEL=="uinput", GROUP="uinput", MODE="0660"
+
+This allows the program to create a virtual device for pasting emojis; without these steps, `Type` mode **will not work**.
 
 
 ### App
 
-There are several ways to install the app, ~~you can install from deb you can
-find on
-[releases page](https://github.com/OzymandiasTheGreat/emoji-keyboard/releases)~~.
+##### Installing via `pip`
 
-You can install with pip
+    sudo -H pip3 install https://github.com/OzymandiasTheGreat/emoji-keyboard/archive/master.zip
 
-`sudo pip3 install
-https://github.com/OzymandiasTheGreat/emoji-keyboard/archive/master.zip`
+##### Installing via `apt` using `ppa` repo courtesy of [atareao](https://github.com/atareao) (latest version not guaranteed)
 
-There's also ppa, courtesy of [atareao](https://github.com/atareao)
-Note that this ppa is NOT maintained by me, so I can't guarantee latest versions.
-
-`sudo add-apt-repository ppa:atareao/atareao`
-
-`sudo apt update`
-
-`sudo apt install emoji-keyboard`
+    sudo add-apt-repository ppa:atareao/atareao
+    sudo apt update
+    sudo apt install emoji-keyboard
 
 ## Usage
 
 ### Keyboard
 
-Selecting `Show Keyboard` from the app indicator menu or, if your desktop
-environment supports it, middle-clicking app indicator will toggle the visibility
-of the keyboard. When the picker is visible simply clicking on emoji will type it
-into focused application.
+To toggle visibility of the keyboard, select `Show Keyboard` from the app indicator menu, or, if supported by your DE, middle-click the app indicator. When the keyboard is visible, simply click an emoji to type it into the focused application.
 
 ### Search
 
-You can search by official unicode name or by :shortname:.
-Pressing `enter` will select and type the first result.
+You can search for emojis by entering a word that pertains to the emoji you're looking for. Click on an emoji or use arrow keys and <kbd>ENTER</kbd> to type an emoji into the focused application.
 
 ### Hotkeys
 
-`emoji-keyboard` can be controlled from the command line. Use your desktop's
-native hotkey utility to assign hotkeys to
-
-`emoji-keyboard -k` to toggle visibility of the keyboard,
-
-`emoji-keyboard -s` to toggle visibility of the search window.
-
-Run `emoji-keyboard -h` in the terminal to get full list of commands.
+If you'd like to assign hotkeys to control the application, use the command `emoji-keyboard -h` to get a list of commands, then use a hotkey utility (most desktop environments have one in their settings application) to assign keybindings to the desired commands.


### PR DESCRIPTION
## Formatting:

- Changed commands that appear on their own line from backtick syntax to codeblock syntax
- Changed headers that used bold text into actual headers
- Added headers where they were missing
- Changed all-caps to bold where it was used for emphasis

- Changed artwork/metadata to a bullet list, added links to the repo authors
- Changed app installation instructions to a list of sub-headers
- Made text surrounded by backticks (indicating a physical keyboard button) use \<kbd> instead

## Grammar/Phrasing:

- Reworded installation instructions for dependencies on machines with `X` to be more professional
- Changed `nano` in installation instructions for dependencies on machines with `Wayland` to generic text editor
- Reworded app installation instructions for `pip` to be more professional
- Edited hotkey instructions to provide more useful information and less unnecessary bulk

## Commands:

- Changed `$(whoami)` to use environmental variable; `$(whoami)` requires the user to have `whoami` installed on their machine
- Added `-H` flag to `pip` app installation instructions; fixes target home directory and removes error messages