### PR TITLE
REMOVE: sudo from pip3 install

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ find on
 
 You can install with pip
 
-`sudo pip3 install
+`pip3 install
 https://github.com/OzymandiasTheGreat/emoji-keyboard/archive/master.zip`
 
 There's also ppa, courtesy of [atareao](https://github.com/atareao)


### PR DESCRIPTION
sudo was causing an error in the `pip3 install` command

```
Collecting https://github.com/OzymandiasTheGreat/emoji-keyboard/archive/master.zip
  Downloading https://github.com/OzymandiasTheGreat/emoji-keyboard/archive/master.zip (12.8MB)
    100% |████████████████████████████████| 12.8MB 180kB/s 
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-4rw0d489-build/setup.py", line 5, in <module>
        from lib.emoji_shared import version
      File "/tmp/pip-4rw0d489-build/lib/emoji_shared.py", line 102, in <module>
        wayland = check_wayland()
      File "/tmp/pip-4rw0d489-build/lib/emoji_shared.py", line 82, in check_wayland
        current_user = current_user if current_user != 'root' else os.getlogin()
    FileNotFoundError: [Errno 2] No such file or directory
```

Running the command without sudo made everything work as expected.