### PR TITLE
Add link to angular-electron template

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ And of course there's eye-candy. Choose emoji set you prefer or app and panel th
 
 &copy; 2020 [Ozymandias (Tomas Ravinskas)](mailto:tomas.rav@gmail.com)
 
+Based on the Angular-Electron template by [Maxime Gris](https://github.com/maximegris/angular-electron).
+
 Emoji artwork and metadata provided by:
 
 [Blobmoji](https://github.com/c1710/blobmoji) by Google Inc. and is licensed under [Apache-2.0](https://github.com/C1710/blobmoji/blob/master/LICENSE)


### PR DESCRIPTION
First of all, thanks for taking the effort of updating the emoji keyboard! :smile: 

I wanted to know where you got the Electron template from, and I had to dig into the commit history to figure this out. I thought I could make this job slightly easier for others by adding a link to the `README.md` :slightly_smiling_face: 